### PR TITLE
F/anu api bootstrap 2

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,3 +1,15 @@
+let _ = require('lodash-firecloud').default;
+let minlogDefaultLevels = require('minlog').defaultLevels;
+
+let minlogFuns = _.concat(_.keys(minlogDefaultLevels), [
+  'trackTime'
+]);
+
+let srcFuns = [];
+srcFuns = _.concat(srcFuns, _.map(minlogFuns, function(level) {
+  return `ctx.log.${level}`;
+}));
+
 module.exports = {
   presets: [
     ['firecloud', {
@@ -5,6 +17,11 @@ module.exports = {
         targets: {
           node: '8.10' // Latest AWS Lambda Node.js
         }
+      },
+
+      'babel-plugin-firecloud-src-arg': {
+        disabled: false,
+        srcFuns
       }
     }]
   ],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express": "^4.16.2",
     "express-bearer-token": "^2.1.1",
     "http-lambda": "git://github.com/tobiipro/http-lambda.git#semver:~0.2.0",
-    "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.3-rc.1",
+    "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.3",
     "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.4",
     "response-time": "^2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express-bearer-token": "^2.1.1",
     "http-lambda": "git://github.com/tobiipro/http-lambda.git#semver:~0.2.0",
     "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.3",
-    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.4",
+    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.11",
     "response-time": "^2.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express-bearer-token": "^2.1.1",
     "http-lambda": "git://github.com/tobiipro/http-lambda.git#semver:~0.2.0",
     "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.3-rc.1",
-    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.1",
+    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.4",
     "response-time": "^2.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express-bearer-token": "^2.1.1",
     "http-lambda": "git://github.com/tobiipro/http-lambda.git#semver:~0.2.0",
     "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.3",
-    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.11",
+    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.14",
     "response-time": "^2.3.2"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
-    "babel-preset-firecloud": "git://github.com/tobiipro/babel-preset-firecloud.git#semver:~0.2.1",
+    "babel-preset-firecloud": "git://github.com/tobiipro/babel-preset-firecloud.git#f/anu-filename-src",
     "eclint": "^2.6.0",
     "eslint": "^5.9.0",
     "eslint-config-firecloud": "git://github.com/tobiipro/eslint-config-firecloud.git#semver:~0.5.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "express-bearer-token": "^2.1.1",
     "http-lambda": "git://github.com/tobiipro/http-lambda.git#semver:~0.2.0",
     "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.3-rc.1",
-    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.0",
+    "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.1",
     "response-time": "^2.3.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express": "^4.16.2",
     "express-bearer-token": "^2.1.1",
     "http-lambda": "git://github.com/tobiipro/http-lambda.git#semver:~0.2.0",
-    "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.1",
+    "lodash-firecloud": "git://github.com/tobiipro/lodash-firecloud.git#semver:~0.2.3-rc.1",
     "minlog": "git://github.com/tobiipro/minlog.git#semver:~0.3.0",
     "response-time": "^2.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^23.6.0",
-    "babel-preset-firecloud": "git://github.com/tobiipro/babel-preset-firecloud.git#f/anu-filename-src",
+    "babel-preset-firecloud": "git://github.com/tobiipro/babel-preset-firecloud.git#semver:~0.2.5",
     "eclint": "^2.6.0",
     "eslint": "^5.9.0",
     "eslint-config-firecloud": "git://github.com/tobiipro/eslint-config-firecloud.git#semver:~0.5.0",

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -96,7 +96,7 @@ export let express = function(e, _ctx, _next) {
   app.use(middlewares.applyMixins());
   app.use(middlewares.xForward());
 
-  app.use(async function(_req, res, next) {
+  app.use(function(_req, res, next) {
     res.set('cache-control', 'max-age=0, no-store');
     next();
   });

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -48,9 +48,9 @@ let _bootstrapLayer = function() {
   };
 };
 
-export let express = function(e) {
+let _bootstrap = async function(fn, e, ctx) {
   _bootstrapLayer();
-  let app = _express();
+  let app = _express(e);
 
   app.disable('x-powered-by');
   app.disable('etag');
@@ -83,6 +83,9 @@ export let express = function(e) {
     next();
   });
 
+  await fn(app, e, ctx);
+
+  // error handlers need to be registered last
   app.use(middlewares.resError());
 
   return app;
@@ -96,14 +99,7 @@ export let bootstrap = function(fn, {
     await ctx.log.trackTime(
       'aws-util-firecloud.express.bootstrap: Creating express app...',
       async function() {
-        app = express(e);
-      }
-    );
-
-    await ctx.log.trackTime(
-      'aws-util-firecloud.express.bootstrap: Setting up custom express...',
-      async function() {
-        await fn(app, e, ctx);
+        app = await _bootstrap(fn, e, ctx);
       }
     );
 

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -89,16 +89,16 @@ export let bootstrap = function(fn, {
   return bootstrapLambda(async function(e, ctx) {
     let app;
     await ctx.log.trackTime(
-      'aws-util-firecloud.express.bootstrap: Creating express app...',
+      'Creating express app...',
       async function() {
         app = await _bootstrap(fn, e, ctx);
       }
     );
 
     let result;
-    ctx.log.info('aws-util-firecloud.express.bootstrap: Creating HTTP server (handling request)...');
+    ctx.log.info('Creating HTTP server (handling request)...');
     await ctx.log.trackTime(
-      'aws-util-firecloud.express.bootstrap: Creating HTTP server (handling request)...',
+      'Creating HTTP server (handling request)...',
       _.promisify(function(done) {
         let http = new LambdaHttp(e, ctx, function(err, resData) {
           if (_.isUndefined(err)) {

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -28,7 +28,7 @@ let _bootstrapLayer = function() {
     if (fn.length === 4 && !this._callbackifiedHandle) {
       // need to keep function arity
       let callbackFn = _.callbackify(async function(err, req, res) {
-        let safeFn = bootstrapResponseError(_.promisify(fn), res);
+        let safeFn = bootstrapResponseError(fn, res);
         return await safeFn(err, req, res);
       });
       this.handle = function(err, req, res, next) {
@@ -47,7 +47,7 @@ let _bootstrapLayer = function() {
     if (fn.length <= 3 && !this._callbackifiedHandle) {
       // need to keep function arity
       let callbackFn = _.callbackify(async function(req, res) {
-        let safeFn = bootstrapResponseError(_.promisify(fn), res);
+        let safeFn = bootstrapResponseError(fn, res);
         return await safeFn(req, res);
       });
       this.handle = function(req, res, next) {

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -78,7 +78,7 @@ let _bootstrap = async function(fn, e, ctx) {
   await fn(app, e, ctx);
 
   // error handlers need to be registered last
-  app.use(middlewares.resError());
+  app.use(middlewares.handleResponseError());
 
   return app;
 };

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -28,9 +28,8 @@ let _bootstrapLayer = function() {
     if (fn.length === 4 && !fn._awsUtilFirecloud) {
       // need to keep function arity
       let callbackFn = _.callbackify(async function(err, req, res) {
-        bootstrapResponseError(async function() {
-          let result = fn(err, req, res);
-          return await _.alwaysPromise(result);
+        return bootstrapResponseError(async function() {
+          return await fn(err, req, res);
         }, res);
       });
       fn = function(err, req, res, next) {
@@ -50,9 +49,8 @@ let _bootstrapLayer = function() {
     if (fn.length <= 3 && !fn._awsUtilFirecloud) {
       // need to keep function arity
       let callbackFn = _.callbackify(async function(req, res) {
-        bootstrapResponseError(async function() {
-          let result = fn(req, res);
-          return await _.alwaysPromise(result);
+        return bootstrapResponseError(async function() {
+          return await fn(req, res);
         }, res);
       });
       fn = function(req, res, next) {

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -13,10 +13,6 @@ import {
 } from '../lambda';
 
 import {
-  bootstrap as bootstrapResponseError
-} from './res-error';
-
-import {
   LambdaHttp
 } from 'http-lambda';
 
@@ -98,6 +94,8 @@ export let express = function(e) {
     res.set('cache-control', 'max-age=0, no-store');
     next();
   });
+
+  app.use(middlewares.resError());
 
   return app;
 };

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -28,7 +28,7 @@ let _bootstrapLayer = function() {
     if (fn.length === 4 && !this._callbackifiedHandle) {
       // need to keep function arity
       let callbackFn = _.callbackify(async function(err, req, res) {
-        let safeFn = bootstrapResponseError(fn, res);
+        let safeFn = bootstrapResponseError(_.promisify(fn), res);
         return await safeFn(err, req, res);
       });
       this.handle = function(err, req, res, next) {
@@ -47,7 +47,7 @@ let _bootstrapLayer = function() {
     if (fn.length <= 3 && !this._callbackifiedHandle) {
       // need to keep function arity
       let callbackFn = _.callbackify(async function(req, res) {
-        let safeFn = bootstrapResponseError(fn, res);
+        let safeFn = bootstrapResponseError(_.promisify(fn), res);
         return await safeFn(req, res);
       });
       this.handle = function(req, res, next) {

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -17,7 +17,7 @@ import {
 } from 'http-lambda';
 
 let _bootstrapLayer = function() {
-  Layer.prototype.handle_error = function(error, req, res, next) {
+  Layer.prototype.handle_error = async function(error, req, res, next) {
     let fn = this.handle;
 
     if (fn.length !== 4) {
@@ -25,14 +25,10 @@ let _bootstrapLayer = function() {
       return next(error);
     }
 
-    try {
-      _.alwaysPromise(fn(error, req, res, next)).catch(next);
-    } catch (err) {
-      return next(err);
-    }
+    await _.alwaysPromise(fn(error, req, res, next)).catch(next);
   };
 
-  Layer.prototype.handle_request = function(req, res, next) {
+  Layer.prototype.handle_request = async function(req, res, next) {
     let fn = this.handle;
 
     if (fn.length > 3) {
@@ -40,11 +36,7 @@ let _bootstrapLayer = function() {
       return next();
     }
 
-    try {
-      _.alwaysPromise(fn(req, res, next)).catch(next);
-    } catch (err) {
-      return next(err);
-    }
+    await _.alwaysPromise(fn(req, res, next)).catch(next);
   };
 };
 

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -17,7 +17,7 @@ import {
 } from 'http-lambda';
 
 let _bootstrapLayer = function() {
-  Layer.prototype.handle_error = async function(error, req, res, next) {
+  Layer.prototype.handle_error = function(error, req, res, next) {
     let fn = this.handle;
 
     if (fn.length !== 4) {
@@ -25,10 +25,14 @@ let _bootstrapLayer = function() {
       return next(error);
     }
 
-    await _.alwaysPromise(fn(error, req, res, next)).catch(next);
+    try {
+      _.alwaysPromise(fn(error, req, res, next)).catch(next);
+    } catch (err) {
+      return next(err);
+    }
   };
 
-  Layer.prototype.handle_request = async function(req, res, next) {
+  Layer.prototype.handle_request = function(req, res, next) {
     let fn = this.handle;
 
     if (fn.length > 3) {
@@ -36,7 +40,11 @@ let _bootstrapLayer = function() {
       return next();
     }
 
-    await _.alwaysPromise(fn(req, res, next)).catch(next);
+    try {
+      _.alwaysPromise(fn(req, res, next)).catch(next);
+    } catch (err) {
+      return next(err);
+    }
   };
 };
 

--- a/src/express/index.js
+++ b/src/express/index.js
@@ -17,7 +17,8 @@ import {
 } from 'http-lambda';
 
 let _bootstrapLayer = function() {
-  Layer.prototype.handle_error = function(error, req, res, next) {
+  // override Layer.prototype as defined in express@4.16.4
+  Layer.prototype.handle_error = async function(error, req, res, next) {
     let fn = this.handle;
 
     if (fn.length !== 4) {
@@ -26,13 +27,15 @@ let _bootstrapLayer = function() {
     }
 
     try {
-      _.alwaysPromise(fn(error, req, res, next)).catch(next);
+      // original code
+      // fn(error, req, res, next);
+      await _.alwaysPromise(fn(error, req, res, next));
     } catch (err) {
       return next(err);
     }
   };
 
-  Layer.prototype.handle_request = function(req, res, next) {
+  Layer.prototype.handle_request = async function(req, res, next) {
     let fn = this.handle;
 
     if (fn.length > 3) {
@@ -41,7 +44,9 @@ let _bootstrapLayer = function() {
     }
 
     try {
-      _.alwaysPromise(fn(req, res, next)).catch(next);
+      // original code
+      // fn(req, res, next);
+      await _.alwaysPromise(fn(req, res, next));
     } catch (err) {
       return next(err);
     }

--- a/src/express/middlewares.js
+++ b/src/express/middlewares.js
@@ -52,7 +52,7 @@ let _sendResponseError = function(res, err) {
 };
 
 export let handleResponseError = function() {
-  return function(err, _req, res, _next) {
+  return function(err, _req, res, next) {
     let {
       ctx
     } = res;
@@ -61,7 +61,7 @@ export let handleResponseError = function() {
 
     if (res.headersSent) {
       ctx.log.error("Headers already sent. Can't send error.");
-      throw err;
+      return next(err);
     }
 
     if (err instanceof ResponseError) {

--- a/src/express/middlewares.js
+++ b/src/express/middlewares.js
@@ -2,24 +2,29 @@ import _ from 'lodash-firecloud';
 import reqMixins from './req-mixins';
 import resMixins from './res-mixins';
 
-export let applyMixins = function(req, res, next) {
-  _.forEach(reqMixins, function(fn, name) {
-    req[name] = _.bind(fn, req);
-  });
+export let applyMixins = function() {
+  return function(req, res, next) {
+    _.forEach(reqMixins, function(fn, name) {
+      req[name] = _.bind(fn, req);
+    });
 
-  res.oldSend = res.send; // required by the res.send mixin
-  _.forEach(resMixins, function(fn, name) {
-    res[name] = _.bind(fn, res);
-  });
+    res.oldSend = res.send; // required by the res.send mixin
+    _.forEach(resMixins, function(fn, name) {
+      res[name] = _.bind(fn, res);
+    });
 
-  next();
+    next();
+  };
 };
 
-export let xForward = function(req, _res, next) {
-  req.headers = _.mapKeys(req.headers, function(_value, key) {
-    return _.replace(key, /^X-Forward-/, '');
-  });
-  next();
+export let xForward = function() {
+  return function(req, _res, next) {
+    req.headers = _.mapKeys(req.headers, function(_value, key) {
+      return _.replace(key, /^X-Forward-/, '');
+    });
+
+    next();
+  };
 };
 
 export default exports;

--- a/src/express/middlewares.js
+++ b/src/express/middlewares.js
@@ -43,10 +43,11 @@ let _sendResponseError = function(res, err) {
     body
   } = err;
 
-  res.status(status);
-
   body.instance = getRequestInstance(res.req);
-  res.send(body, contentType);
+
+  res.status(status);
+  res.type(contentType);
+  res.send(body);
 };
 
 export let handleResponseError = function() {

--- a/src/express/middlewares.js
+++ b/src/express/middlewares.js
@@ -2,14 +2,17 @@ import _ from 'lodash-firecloud';
 import reqMixins from './req-mixins';
 import resMixins from './res-mixins';
 
+let _reqMixins = _.omit(reqMixins, 'default');
+let _resMixins = _.omit(resMixins, 'default');
+
 export let applyMixins = function() {
   return function(req, res, next) {
-    _.forEach(reqMixins, function(fn, name) {
+    _.forEach(_reqMixins, function(fn, name) {
       req[name] = _.bind(fn, req);
     });
 
     res.oldSend = res.send; // required by the res.send mixin
-    _.forEach(resMixins, function(fn, name) {
+    _.forEach(_resMixins, function(fn, name) {
       res[name] = _.bind(fn, res);
     });
 

--- a/src/express/middlewares.js
+++ b/src/express/middlewares.js
@@ -18,6 +18,7 @@ export let applyMixins = function() {
     });
 
     res.oldSend = res.send; // required by the res.send mixin
+    res.oldType = res.type; // required by the res.type mixin
     _.forEach(_resMixins, function(fn, name) {
       res[name] = _.bind(fn, res);
     });

--- a/src/express/res-error.js
+++ b/src/express/res-error.js
@@ -19,7 +19,7 @@ ResponseError.prototype = new Error();
 export let bootstrap = function(fn, res) {
   return async function(...args) {
     try {
-      return await fn(...args);
+      return await _.alwaysPromise(fn(...args));
     } catch (err) {
       let {
         ctx

--- a/src/express/res-error.js
+++ b/src/express/res-error.js
@@ -19,7 +19,7 @@ ResponseError.prototype = new Error();
 export let bootstrap = function(fn, res) {
   return async function(...args) {
     try {
-      await fn(...args);
+      return await fn(...args);
     } catch (err) {
       let {
         ctx
@@ -29,12 +29,11 @@ export let bootstrap = function(fn, res) {
 
       if (res.headersSent) {
         ctx.log.error("Headers already sent. Can't send error.");
-        throw err;
       }
 
       if (err instanceof ResponseError) {
         ctx.log.error(`Responding with ${err.code} ${err.message}...`);
-        return res.sendError(err);
+        res.sendError(err);
       }
 
       if (res.ctx.log._canTrace) {
@@ -43,7 +42,7 @@ export let bootstrap = function(fn, res) {
           renderer: pkg.name,
           trace: err.stack ? _.split(err.stack, '\n') : err
         });
-        return res.sendError(internalErr);
+        res.sendError(internalErr);
       }
 
       throw err;

--- a/src/express/res-error.js
+++ b/src/express/res-error.js
@@ -15,10 +15,4 @@ export let ResponseError = function(status, extensions = {}) {
 };
 ResponseError.prototype = new Error();
 
-export let bootstrap = function(fn, _res) {
-  return async function(...args) {
-    return await _.alwaysPromise(fn(...args));
-  };
-};
-
 export default ResponseError;

--- a/src/express/res-error.js
+++ b/src/express/res-error.js
@@ -27,6 +27,10 @@ export let bootstrap = function(fn, res) {
 
       ctx.log.error({err});
 
+      if (!_.isFunction(res.sendError)) {
+        throw err;
+      }
+
       if (res.headersSent) {
         ctx.log.error("Headers already sent. Can't send error.");
       }

--- a/src/express/res-error.js
+++ b/src/express/res-error.js
@@ -25,7 +25,7 @@ export let bootstrap = function(fn, res) {
         ctx
       } = res;
 
-      res.log.error({err});
+      ctx.log.error({err});
 
       if (res.headersSent) {
         ctx.log.error("Headers already sent. Can't send error.");

--- a/src/express/res-error.js
+++ b/src/express/res-error.js
@@ -1,6 +1,5 @@
 import _ from 'lodash-firecloud';
 import http from 'http';
-import pkg from '../../package.json';
 
 export let ResponseError = function(status, extensions = {}) {
   this.code = status;
@@ -16,41 +15,9 @@ export let ResponseError = function(status, extensions = {}) {
 };
 ResponseError.prototype = new Error();
 
-export let bootstrap = function(fn, res) {
+export let bootstrap = function(fn, _res) {
   return async function(...args) {
-    try {
-      return await _.alwaysPromise(fn(...args));
-    } catch (err) {
-      let {
-        ctx
-      } = res;
-
-      ctx.log.error({err});
-
-      if (!_.isFunction(res.sendError)) {
-        throw err;
-      }
-
-      if (res.headersSent) {
-        ctx.log.error("Headers already sent. Can't send error.");
-      }
-
-      if (err instanceof ResponseError) {
-        ctx.log.error(`Responding with ${err.code} ${err.message}...`);
-        res.sendError(err);
-      }
-
-      if (res.ctx.log._canTrace) {
-        ctx.log.info('Responding with trace...');
-        let internalErr = new ResponseError(500, {
-          renderer: pkg.name,
-          trace: err.stack ? _.split(err.stack, '\n') : err
-        });
-        res.sendError(internalErr);
-      }
-
-      throw err;
-    }
+    return await _.alwaysPromise(fn(...args));
   };
 };
 

--- a/src/express/res-mixins.js
+++ b/src/express/res-mixins.js
@@ -21,12 +21,8 @@ export let addLink = function(link) {
   this.setHeader('link', linkHeader);
 };
 
-export let send = function(body, mediaType) {
+export let send = function(body) {
   this.send = this.oldSend;
-
-  if (mediaType) {
-    this.set('content-type', mediaType);
-  }
 
   if (!_.isUndefined(this.validate) &&
       _.startsWith(this.get('content-type'), this.validate.schema.mediaType)
@@ -44,6 +40,14 @@ export let send = function(body, mediaType) {
   }
 
   return this.send(body);
+};
+
+export let type = function(type) {
+  if (_.isUndefined(type)) {
+    return;
+  }
+
+  this.oldType(type);
 };
 
 export default exports;

--- a/src/express/res-mixins.js
+++ b/src/express/res-mixins.js
@@ -24,12 +24,16 @@ export let addLink = function(link) {
 export let send = function(body) {
   this.send = this.oldSend;
 
+  let {
+    ctx
+  } = this;
+
   if (!_.isUndefined(this.validate) &&
       _.startsWith(this.get('content-type'), this.validate.schema.mediaType)
   ) {
     let valid = this.validate(body);
     if (!valid) {
-      this.log.warn({
+      ctx.log.warn({
         errors: this.validate.errors,
         body,
         schema: this.validate.schema,

--- a/src/express/res-mixins.js
+++ b/src/express/res-mixins.js
@@ -1,10 +1,6 @@
 /* eslint-disable no-invalid-this */
 import _ from 'lodash-firecloud';
 
-import {
-  getRequestInstance
-} from '../lambda';
-
 export let addLink = function(link) {
   let {
     target
@@ -48,21 +44,6 @@ export let send = function(body, mediaType) {
   }
 
   return this.send(body);
-};
-
-export let sendError = function(responseError) {
-  let {
-    code: status,
-    contentType,
-    body
-  } = responseError;
-
-  this.status(status);
-
-  body.instance = getRequestInstance(this.req);
-  this.send(body, contentType);
-
-  return responseError;
 };
 
 export default exports;

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -55,6 +55,10 @@ let _bootstrap = async function(fn, e, ctx, pkg) {
     'aws-util-firecloud.lambda.bootstrap: Running fn...',
     async function() {
       result = await _.alwaysPromise(fn(e, ctx));
+
+      ctx.log.trace('Lambda result', {
+        result
+      });
     }
   );
 

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -55,10 +55,6 @@ let _bootstrap = async function(fn, e, ctx, pkg) {
     'aws-util-firecloud.lambda.bootstrap: Running fn...',
     async function() {
       result = await _.alwaysPromise(fn(e, ctx));
-
-      ctx.log.trace('Lambda result', {
-        result
-      });
     }
   );
 
@@ -97,10 +93,18 @@ export let bootstrap = function(fn, {
         result
       };
 
+
+      ctx.log.trace('Lambda result', nextOnce.called);
+
       next(err, result);
     };
 
-    await _bootstrap(fn, e, ctx, pkg, nextOnce);
+    try {
+      let result = await _bootstrap(fn, e, ctx, pkg);
+      nextOnce(undefined, result);
+    } catch (err) {
+      nextOnce(err);
+    }
   };
 };
 

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -10,6 +10,60 @@ import {
   setup as setupLogger
 } from './logger';
 
+let _cleanup = async function({ctx}) {
+  if (global && global.gc) {
+    await ctx.log.trackTime(
+      'aws-util-firecloud.lambda.bootstrap: Garbage collection on demand...',
+      async function() {
+        global.gc();
+      }
+    );
+  }
+};
+
+let _bootstrap = async function({fn, e, ctx, pkg}) {
+  // temporary logger
+  setupLogger({ctx});
+
+  await ctx.log.trackTime(
+    'aws-util-firecloud.lambda.bootstrap: Merging env ctx...',
+    async function() {
+      await mergeEnvCtx({e, ctx, pkg});
+    }
+  );
+
+  await ctx.log.trackTime(
+    'aws-util-firecloud.lambda.bootstrap: Setting up logger...',
+    async function() {
+      setupLogger({ctx});
+      ctx.log.trace(`Logger started. ${ctx.log.level()}`, {
+        e,
+        ctx
+      });
+    }
+  );
+
+  await ctx.log.trackTime(
+    'aws-util-firecloud.lambda.bootstrap: Inspecting...',
+    async function() {
+      await inspect({e, ctx});
+    }
+  );
+
+  let result;
+  await ctx.log.trackTime(
+    'aws-util-firecloud.lambda.bootstrap: Running fn...',
+    async function() {
+      result = await fn(e, ctx);
+    }
+  );
+
+  // don't wait for cleanup on purpose
+  _cleanup({ctx});
+
+  return result;
+};
+
 export let getRequestInstance = function(req) {
   let {
     ctx
@@ -21,49 +75,7 @@ export let bootstrap = function(fn, {
   pkg
 }) {
   return _.callbackify(async function(e, ctx) {
-    // temporary logger
-    setupLogger({ctx});
-
-    await ctx.log.trackTime(
-      'aws-util-firecloud.lambda.bootstrap: Merging env ctx...',
-      async function() {
-        await mergeEnvCtx({e, ctx, pkg});
-      }
-    );
-
-    await ctx.log.trackTime(
-      'aws-util-firecloud.lambda.bootstrap: Setting up logger...',
-      async function() {
-        setupLogger({ctx});
-        ctx.log.trace(`Logger started. ${ctx.log.level()}`, {
-          e,
-          ctx
-        });
-      }
-    );
-
-    await ctx.log.trackTime(
-      'aws-util-firecloud.lambda.bootstrap: Inspecting...',
-      async function() {
-        await inspect({e, ctx});
-      }
-    );
-
-    await ctx.log.trackTime(
-      'aws-util-firecloud.lambda.bootstrap: Running fn...',
-      async function() {
-        await fn(e, ctx);
-      }
-    );
-
-    if (global && global.gc) {
-      await ctx.log.trackTime(
-        'aws-util-firecloud.lambda.bootstrap: Garbage collection on demand...',
-        async function() {
-          global.gc();
-        }
-      );
-    }
+    return await _bootstrap({fn, e, ctx, pkg});
   });
 };
 

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -17,17 +17,10 @@ export let getRequestInstance = function(req) {
   return `${ctx.invokedFunctionArn}#request:${ctx.awsRequestId}`;
 };
 
-export let asyncHandler = function(fn) {
-  return function(...args) {
-    let next = args[args.length - 1];
-    fn(...args).catch(next);
-  };
-};
-
 export let bootstrap = function(fn, {
   pkg
 }) {
-  return asyncHandler(async function(e, ctx, next) {
+  return _.callbackify(async function(e, ctx) {
     // temporary logger
     setupLogger({ctx});
 
@@ -59,7 +52,7 @@ export let bootstrap = function(fn, {
     await ctx.log.trackTime(
       'aws-util-firecloud.lambda.bootstrap: Running fn...',
       async function() {
-        await fn(e, ctx, next);
+        await fn(e, ctx);
       }
     );
 

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -74,7 +74,7 @@ export let getRequestInstance = function(req) {
 export let bootstrap = function(fn, {
   pkg
 }) {
-  return function(e, ctx, next) {
+  return async function(e, ctx, next) {
     let nextOnce = function(err, result) {
       if (nextOnce.called) {
         ctx.log.warn('Skip sending a new lambda response. One was already sent', {
@@ -94,7 +94,8 @@ export let bootstrap = function(fn, {
 
       next(err, result);
     };
-    _.callbackify(_bootstrap)(fn, e, ctx, pkg, nextOnce);
+
+    await _bootstrap(fn, e, ctx, pkg, nextOnce);
   };
 };
 

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -79,7 +79,13 @@ export let bootstrap = function(fn, {
       let result = await _bootstrap(fn, e, ctx, pkg);
       return awsNext(undefined, result);
     } catch (err) {
-      return awsNext(err);
+      // proxying the err to awsNext would not reset state (kill lambda)
+      // return awsNext(err);
+
+      // eslint-disable-next-line no-console
+      console.error(err);
+      // eslint-disable-next-line no-process-exit
+      process.exit(1);
     }
   };
 };

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -74,12 +74,12 @@ export let getRequestInstance = function(req) {
 export let bootstrap = function(fn, {
   pkg
 }) {
-  return async function(e, ctx, next) {
+  return async function(e, ctx, awsNext) {
     try {
       let result = await _bootstrap(fn, e, ctx, pkg);
-      return next(undefined, result);
+      return awsNext(undefined, result);
     } catch (err) {
-      return next(err);
+      return awsNext(err);
     }
   };
 };

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -64,11 +64,6 @@ export let bootstrap = function(fn, {
         }
       );
     }
-
-    ctx.log.debug('Execution time report:');
-    _.forEach(ctx.log.trackTime.reports, function(report) {
-      ctx.log.debug(report);
-    });
   });
 };
 

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -77,14 +77,15 @@ export let bootstrap = function(fn, {
   return async function(e, ctx, next) {
     let nextOnce = function(err, result) {
       if (nextOnce.called) {
-        ctx.log.warn('Skip sending a new lambda response. One was already sent', {
-          previous: nextOnce.called,
-          current: {
+        let err = new Error('Lambda response was already sent!');
+        ctx.log.error(err, {
+          previousArgs: nextOnce.called,
+          currentArgs: {
             err,
             result
           }
         });
-        return;
+        throw err;
       }
 
       nextOnce.called = {

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -75,35 +75,11 @@ export let bootstrap = function(fn, {
   pkg
 }) {
   return async function(e, ctx, next) {
-    let nextOnce = function(err, result) {
-      if (nextOnce.called) {
-        let err = new Error('Lambda response was already sent!');
-        ctx.log.error(err, {
-          previousArgs: nextOnce.called,
-          currentArgs: {
-            err,
-            result
-          }
-        });
-        throw err;
-      }
-
-      nextOnce.called = {
-        err,
-        result
-      };
-
-
-      ctx.log.trace('Lambda result', nextOnce.called);
-
-      next(err, result);
-    };
-
     try {
       let result = await _bootstrap(fn, e, ctx, pkg);
-      nextOnce(undefined, result);
+      return next(undefined, result);
     } catch (err) {
-      nextOnce(err);
+      return next(err);
     }
   };
 };

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -36,7 +36,7 @@ let _bootstrap = async function(fn, e, ctx, pkg) {
     'aws-util-firecloud.lambda.bootstrap: Setting up logger...',
     async function() {
       setupLogger({ctx});
-      ctx.log.trace(`Logger started. ${ctx.log.level()}`, {
+      ctx.log.trace(`Logger started with level=${ctx.log.level()}`, {
         e,
         ctx
       });

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -13,7 +13,7 @@ import {
 let _cleanup = async function({ctx}) {
   if (global && global.gc) {
     await ctx.log.trackTime(
-      'aws-util-firecloud.lambda.bootstrap: Garbage collection on demand...',
+      'Garbage collection on demand...',
       async function() {
         global.gc();
       }
@@ -26,14 +26,14 @@ let _bootstrap = async function(fn, e, ctx, pkg) {
   setupLogger({ctx});
 
   await ctx.log.trackTime(
-    'aws-util-firecloud.lambda.bootstrap: Merging env ctx...',
+    'Merging env ctx...',
     async function() {
       await mergeEnvCtx({e, ctx, pkg});
     }
   );
 
   await ctx.log.trackTime(
-    'aws-util-firecloud.lambda.bootstrap: Setting up logger...',
+    'Setting up logger...',
     async function() {
       setupLogger({ctx});
       ctx.log.trace(`Logger started with level=${ctx.log.level()}`, {
@@ -44,7 +44,7 @@ let _bootstrap = async function(fn, e, ctx, pkg) {
   );
 
   await ctx.log.trackTime(
-    'aws-util-firecloud.lambda.bootstrap: Inspecting...',
+    'Inspecting...',
     async function() {
       await inspect({e, ctx});
     }
@@ -52,7 +52,7 @@ let _bootstrap = async function(fn, e, ctx, pkg) {
 
   let result;
   await ctx.log.trackTime(
-    'aws-util-firecloud.lambda.bootstrap: Running fn...',
+    'Running fn...',
     async function() {
       result = await _.alwaysPromise(fn(e, ctx));
     }

--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -54,7 +54,7 @@ let _bootstrap = async function({fn, e, ctx, pkg}) {
   await ctx.log.trackTime(
     'aws-util-firecloud.lambda.bootstrap: Running fn...',
     async function() {
-      result = await fn(e, ctx);
+      result = await _.alwaysPromise(fn(e, ctx));
     }
   );
 

--- a/src/lambda/logger.js
+++ b/src/lambda/logger.js
@@ -93,6 +93,7 @@ export let setup = function({ctx}) {
     ],
     listeners: [
       logToConsole({
+        contextId: ctx.awsRequestId,
         level
       })
     ]

--- a/src/lambda/logger.js
+++ b/src/lambda/logger.js
@@ -3,17 +3,16 @@ import aws from 'aws-sdk';
 
 import {
   MinLog,
-  logToConsole,
+  logToConsoleAwsLambda,
   serializeErr,
   serializeTime
 } from 'minlog';
 
-let _makeLambdaSerializer = function({ctx}) {
+let _makeCtxSerializer = function({ctx}) {
   return async function({entry}) {
-    entry.lambda = {
-      awsRequestId: ctx.awsRequestId,
-      functionName: ctx.functionName
-    };
+    entry.ctx = _.pick(ctx, [
+      'awsRequestId'
+    ]);
 
     return entry;
   };
@@ -89,11 +88,10 @@ export let setup = function({ctx}) {
     serializers: [
       serializeTime,
       serializeErr,
-      _makeLambdaSerializer({ctx})
+      _makeCtxSerializer({ctx})
     ],
     listeners: [
-      logToConsole({
-        contextId: ctx.awsRequestId,
+      logToConsoleAwsLambda({
         level
       })
     ]

--- a/test/express/index.test.js
+++ b/test/express/index.test.js
@@ -1,0 +1,202 @@
+/* eslint-disable jest/no-test-callback */
+
+import ResponseError from '../../src/express/res-error';
+import _ from 'lodash-firecloud';
+import envCtx from '../../src/lambda/env-ctx';
+import express from '../../src/express';
+
+describe('express', function() {
+  describe('bootstrap', function() {
+    it("should call AWS' next with the handler's HTTP response", function(done) {
+      let spyMergeEnvCtx = jest.spyOn(envCtx, 'merge')
+        .mockImplementation(_.noop);
+
+      let expectedResult = 'expected result';
+      let handler = async function(app, _e, _ctx) {
+        app.use(function(_req, res, _next) {
+          res.send(expectedResult);
+        });
+      };
+
+      let bHandler = express.bootstrap(handler, {
+        pkg: {
+          name: 'test'
+        }
+      });
+
+      let e = {};
+      let ctx = {};
+      bHandler(e, ctx, function(err, result) {
+        expect(err).toBeUndefined();
+        expect(result).toMatchObject({
+          statusCode: 200,
+          headers: {
+            'content-length': '15'
+          },
+          body: expectedResult
+        });
+
+        expect(spyMergeEnvCtx).toHaveBeenCalled();
+        spyMergeEnvCtx.mockReset();
+        spyMergeEnvCtx.mockRestore();
+        done();
+      });
+    });
+
+    it("should call AWS' next with the handler's exception", function(done) {
+      let spyMergeEnvCtx = jest.spyOn(envCtx, 'merge')
+        .mockImplementation(_.noop);
+
+      let expectedErr = new Error();
+      let handler = async function(_app, _e, _ctx) {
+        throw expectedErr;
+      };
+
+      let bHandler = express.bootstrap(handler, {
+        pkg: {
+          name: 'test'
+        }
+      });
+
+      let e = {};
+      let ctx = {};
+      bHandler(e, ctx, function(err, result) {
+        expect(err).toBe(expectedErr);
+        expect(result).toBeUndefined();
+
+        expect(spyMergeEnvCtx).toHaveBeenCalled();
+        spyMergeEnvCtx.mockReset();
+        spyMergeEnvCtx.mockRestore();
+        done();
+      });
+    });
+
+    it("should call AWS' next with the (sync) middleware's exception", async function() {
+      let spyMergeEnvCtx = jest.spyOn(envCtx, 'merge')
+        .mockImplementation(_.noop);
+
+      let spyExitResolve;
+      let spyExitPromise = new Promise(function(resolve, _reject) {
+        spyExitResolve = resolve;
+      });
+      let spyExit = jest.spyOn(process, 'exit')
+        .mockImplementation(function(...args) {
+          spyExitResolve(args);
+        });
+
+      let expectedErr = new Error();
+      let handler = async function(app, _e, _ctx) {
+        app.use(function(_req, _res, _next) {
+          throw expectedErr;
+        });
+      };
+
+      let bHandler = express.bootstrap(handler, {
+        pkg: {
+          name: 'test'
+        }
+      });
+
+      let e = {};
+      let ctx = {};
+      bHandler(e, ctx, _.noop);
+
+      let exitArgs = await spyExitPromise;
+      expect(exitArgs).toStrictEqual([
+        1
+      ]);
+
+      expect(spyExit).toHaveBeenCalledTimes(1);
+      spyExit.mockReset();
+      spyExit.mockRestore();
+
+      expect(spyMergeEnvCtx).toHaveBeenCalled();
+      spyMergeEnvCtx.mockReset();
+      spyMergeEnvCtx.mockRestore();
+    });
+
+    it("should call AWS' next with the (async) middleware's exception", async function() {
+      let spyMergeEnvCtx = jest.spyOn(envCtx, 'merge')
+        .mockImplementation(_.noop);
+
+      let spyExitResolve;
+      let spyExitPromise = new Promise(function(resolve, _reject) {
+        spyExitResolve = resolve;
+      });
+      let spyExit = jest.spyOn(process, 'exit')
+        .mockImplementation(function(...args) {
+          spyExitResolve(args);
+        });
+
+      let expectedErr = new Error();
+      let handler = async function(app, _e, _ctx) {
+        app.use(async function(_req, _res, _next) {
+          throw expectedErr;
+        });
+      };
+
+      let bHandler = express.bootstrap(handler, {
+        pkg: {
+          name: 'test'
+        }
+      });
+
+      let e = {};
+      let ctx = {};
+      bHandler(e, ctx, _.noop);
+
+      let exitArgs = await spyExitPromise;
+      expect(exitArgs).toStrictEqual([
+        1
+      ]);
+
+      expect(spyExit).toHaveBeenCalledTimes(1);
+      spyExit.mockReset();
+      spyExit.mockRestore();
+
+      expect(spyMergeEnvCtx).toHaveBeenCalled();
+      spyMergeEnvCtx.mockReset();
+      spyMergeEnvCtx.mockRestore();
+    });
+
+    it("should call AWS' next with the (async) middleware's ResponseError", function(done) {
+      let spyMergeEnvCtx = jest.spyOn(envCtx, 'merge')
+        .mockImplementation(_.noop);
+
+      let expectedStatusCode = 404;
+      let expectedDetails = {
+        test: true
+      };
+      let handler = async function(app, _e, _ctx) {
+        app.use(async function(_req, _res, _next) {
+          throw new ResponseError(expectedStatusCode, expectedDetails);
+        });
+      };
+
+      let bHandler = express.bootstrap(handler, {
+        pkg: {
+          name: 'test'
+        }
+      });
+
+      let e = {};
+      let ctx = {};
+
+      bHandler(e, ctx, function(err, result) {
+        expect(err).toBeUndefined();
+        expect(result).toMatchObject({
+          statusCode: expectedStatusCode,
+          headers: {
+            'content-type': 'application/problem+json; charset=utf-8'
+          }
+        });
+        expect(JSON.parse(result.body)).toMatchObject(expectedDetails);
+
+        expect(spyMergeEnvCtx).toHaveBeenCalled();
+        spyMergeEnvCtx.mockReset();
+        spyMergeEnvCtx.mockRestore();
+        done();
+      });
+    });
+  });
+});

--- a/test/firehose.test.js
+++ b/test/firehose.test.js
@@ -39,7 +39,6 @@ describe('firehose', function() {
 
       expect(spy).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -70,7 +69,6 @@ when batch byteSize < ${firehose.limits.batchByteSize / 1024 / 1024} MB`, async 
 
       expect(spy).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -102,7 +100,6 @@ when batch count < ${firehose.limits.batchRecord}`, async function() {
 
       expect(spy).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -144,7 +141,6 @@ when batch count < ${firehose.limits.batchRecord}`, async function() {
       expect(spy).toHaveBeenCalled();
       expect(spy2).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -176,7 +172,6 @@ when batch count < ${firehose.limits.batchRecord}`, async function() {
 
       expect(failed).toBe(true);
 
-      spy.mockReset();
       spy.mockRestore();
     });
   });

--- a/test/firehose.test.js
+++ b/test/firehose.test.js
@@ -129,7 +129,7 @@ when batch count < ${firehose.limits.batchRecord}`, async function() {
           throw new Error();
         })
         .mockImplementationOnce(function(...args) {
-          expect(args[0]).toMatch(/Skipping record larger than/);
+          expect(args[1]).toMatch(/Skipping record larger than/);
         });
 
       await firehose.putRecords({

--- a/test/kinesis.test.js
+++ b/test/kinesis.test.js
@@ -135,7 +135,7 @@ when batch count < ${kinesis.limits.batchRecord}`, async function() {
           throw new Error();
         })
         .mockImplementationOnce(function(...args) {
-          expect(args[0]).toMatch(/Skipping record larger than/);
+          expect(args[1]).toMatch(/Skipping record larger than/);
         });
 
       await kinesis.putRecords({

--- a/test/kinesis.test.js
+++ b/test/kinesis.test.js
@@ -43,7 +43,6 @@ describe('kinesis', function() {
 
       expect(spy).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -75,7 +74,6 @@ when batch byteSize < ${kinesis.limits.batchByteSize / 1024 / 1024} MB`, async f
 
       expect(spy).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -108,7 +106,6 @@ when batch count < ${kinesis.limits.batchRecord}`, async function() {
 
       expect(spy).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -151,7 +148,6 @@ when batch count < ${kinesis.limits.batchRecord}`, async function() {
       expect(spy).toHaveBeenCalled();
       expect(spy2).toHaveBeenCalled();
 
-      spy.mockReset();
       spy.mockRestore();
     });
 
@@ -184,7 +180,6 @@ when batch count < ${kinesis.limits.batchRecord}`, async function() {
 
       expect(failed).toBe(true);
 
-      spy.mockReset();
       spy.mockRestore();
     });
   });

--- a/test/lambda/index.test.js
+++ b/test/lambda/index.test.js
@@ -1,0 +1,65 @@
+/* eslint-disable jest/no-test-callback */
+
+import _ from 'lodash-firecloud';
+import envCtx from '../../src/lambda/env-ctx';
+import lambda from '../../src/lambda';
+
+describe('lambda', function() {
+  describe('bootstrap', function() {
+    it("should call AWS' next with the handler's result", function(done) {
+      let spy = jest.spyOn(envCtx, 'merge')
+        .mockImplementation(_.noop);
+
+      let expectedResult = Symbol('result');
+      let handler = async function(_e, _ctx) {
+        return expectedResult;
+      };
+
+      let bHandler = lambda.bootstrap(handler, {
+        pkg: {
+          name: 'test'
+        }
+      });
+
+      let e = {};
+      let ctx = {};
+      bHandler(e, ctx, function(err, result) {
+        expect(err).toBeUndefined();
+        expect(result).toBe(expectedResult);
+
+        expect(spy).toHaveBeenCalled();
+        spy.mockReset();
+        spy.mockRestore();
+        done();
+      });
+    });
+
+    it("should call AWS' next with the handler's exception", function(done) {
+      let spy = jest.spyOn(envCtx, 'merge')
+        .mockImplementation(_.noop);
+
+      let expectedErr = new Error();
+      let handler = async function(_e, _ctx) {
+        throw expectedErr;
+      };
+
+      let bHandler = lambda.bootstrap(handler, {
+        pkg: {
+          name: 'test'
+        }
+      });
+
+      let e = {};
+      let ctx = {};
+      bHandler(e, ctx, function(err, result) {
+        expect(err).toBe(expectedErr);
+        expect(result).toBeUndefined();
+
+        expect(spy).toHaveBeenCalled();
+        spy.mockReset();
+        spy.mockRestore();
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes:
* Breaking change: [x]

---

<!-- Describe your contribution -->

breaking changes:
* removed
  * `asyncHandler`
  * `bootstrap` (express-middleware.js)
  * `res.sendError` ~~should maybe even remove `res.sendError` mixin? since it's eclipsed by `throw new ResponseError()`~~ 🤔 
  * 2nd argument (type) in `res.send`
* non-http lambdas need to throw or return the response
* http (express) lambdas need to throw (preferably `ResponseError`) or call `res.(s)end` or return the response
* no need to wrap middlewares anymore, just the handlers with the `bootstrap` function from `aws-util-firecloud/lib/{lambda,express}`
