### PR TITLE
Athena pagination

### DIFF
--- a/src/athena.js
+++ b/src/athena.js
@@ -139,7 +139,8 @@ export let executeQuery = async function({
     }
   },
   pollingDelay = 1000,
-  initPollingDelay = pollingDelay
+  initPollingDelay = pollingDelay,
+  maxRows = 10000
 }) {
   let queryExecutionData = await athena.startQueryExecution(params).promise();
   let {
@@ -157,15 +158,29 @@ export let executeQuery = async function({
     throw Error("Athena: query didn't succeed.");
   }
 
-  let queryResult = await athena.getQueryResults({QueryExecutionId}).promise();
+  let queryResult;
+  let nextToken;
+  let rows = [];
+  do {
+    queryResult = await athena.getQueryResults({QueryExecutionId, NextToken: nextToken}).promise();
 
-  if (queryResultIsShowResult(queryResult)) {
-    return queryResultToText(queryResult);
-  }
+    // checking if the query is a result of SHOW query
+    // returing just text in this case, not trying to parse columns and rows
+    if (queryResultIsShowResult(queryResult)) {
+      return queryResultToText(queryResult);
+    }
 
-  let resultObject = queryResultToObjectsArray(queryResult);
-  resultObject = _.drop(resultObject, 1); // first row is column names
-  return resultObject;
+    nextToken = queryResult.NextToken;
+
+    rows = rows.concat(queryResultToObjectsArray(queryResult));
+    if (rows.length > maxRows) {
+      break;
+    }
+  } while (nextToken);
+
+  rows = _.drop(rows, 1); // first row is column names
+  rows = _.take(rows, maxRows);
+  return rows;
 };
 
 export default exports;

--- a/src/athena.js
+++ b/src/athena.js
@@ -63,25 +63,21 @@ export let queryResultToObjectsArray = function(queryResult) {
     _.forEach(columns, function(column, columnIndex) {
       let value = _.get(row, `Data[${columnIndex}].VarCharValue`);
 
-      try {
-        if (_.isDefined(value)) {
-          switch (_.toLower(column.Type)) {
-          case ('integer'):
-          case ('tinyint'):
-          case ('smallint'):
-          case ('bigint'):
-          case ('double'):
-            value = Number(value);
-            break;
-          case ('boolean'):
-            value = Boolean(value);
-            break;
-          default:
-            break;
-          }
+      if (_.isDefined(value)) {
+        switch (_.toLower(column.Type)) {
+        case ('integer'):
+        case ('tinyint'):
+        case ('smallint'):
+        case ('bigint'):
+        case ('double'):
+          value = Number(value);
+          break;
+        case ('boolean'):
+          value = Boolean(value);
+          break;
+        default:
+          break;
         }
-      } catch (_err) {
-        // didn't manage to convert, keeping string
       }
 
       rowObject[column.Name] = value;
@@ -177,7 +173,10 @@ export let executeQuery = async function({
     nextToken = queryResult.NextToken;
 
     rows = rows.concat(queryResultToObjectsArray(queryResult));
-  } while (nextToken && rows.length <= maxRows);
+    if (rows.length > maxRows) {
+      break;
+    }
+  } while (nextToken);
 
   rows = _.drop(rows, 1); // first row is column names
   rows = _.take(rows, maxRows);

--- a/src/athena.js
+++ b/src/athena.js
@@ -63,21 +63,25 @@ export let queryResultToObjectsArray = function(queryResult) {
     _.forEach(columns, function(column, columnIndex) {
       let value = _.get(row, `Data[${columnIndex}].VarCharValue`);
 
-      if (_.isDefined(value)) {
-        switch (_.toLower(column.Type)) {
-        case ('integer'):
-        case ('tinyint'):
-        case ('smallint'):
-        case ('bigint'):
-        case ('double'):
-          value = Number(value);
-          break;
-        case ('boolean'):
-          value = Boolean(value);
-          break;
-        default:
-          break;
+      try {
+        if (_.isDefined(value)) {
+          switch (_.toLower(column.Type)) {
+          case ('integer'):
+          case ('tinyint'):
+          case ('smallint'):
+          case ('bigint'):
+          case ('double'):
+            value = Number(value);
+            break;
+          case ('boolean'):
+            value = Boolean(value);
+            break;
+          default:
+            break;
+          }
         }
+      } catch (_err) {
+        // didn't manage to convert, keeping string
       }
 
       rowObject[column.Name] = value;
@@ -173,10 +177,7 @@ export let executeQuery = async function({
     nextToken = queryResult.NextToken;
 
     rows = rows.concat(queryResultToObjectsArray(queryResult));
-    if (rows.length > maxRows) {
-      break;
-    }
-  } while (nextToken);
+  } while (nextToken && rows.length <= maxRows);
 
   rows = _.drop(rows, 1); // first row is column names
   rows = _.take(rows, maxRows);

--- a/src/athena.js
+++ b/src/athena.js
@@ -139,8 +139,7 @@ export let executeQuery = async function({
     }
   },
   pollingDelay = 1000,
-  initPollingDelay = pollingDelay,
-  maxRows = 10000
+  initPollingDelay = pollingDelay
 }) {
   let queryExecutionData = await athena.startQueryExecution(params).promise();
   let {
@@ -173,13 +172,9 @@ export let executeQuery = async function({
     nextToken = queryResult.NextToken;
 
     rows = rows.concat(queryResultToObjectsArray(queryResult));
-    if (rows.length > maxRows) {
-      break;
-    }
   } while (nextToken);
 
   rows = _.drop(rows, 1); // first row is column names
-  rows = _.take(rows, maxRows);
   return rows;
 };
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Make sure that `make all test` passes!

https://github.com/tobiipro/support-firecloud/blob/master/doc/working-with-git-pr.md :
0. Small is Best
1. Correct
2. Consistent
3. Readable
4. Share Knowledge
-->

* Fixes: #29 
* Breaking change: [ ]

---

<!-- Describe your contribution -->
Added pagination for high-level function `executeQuery`. By default, it will allow 10000 rows, but configurable.

SIDENOTE: Also, I would like to improve a bit the API for `athena` functions, make it tighter, but it will be a breaking change. 